### PR TITLE
Add depending mrbgems.

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,6 +2,10 @@ MRuby::Gem::Specification.new('mruby-require') do |spec|
   spec.license = 'MIT'
   spec.authors = 'Internet Initiative Japan Inc.'
 
+  ['mruby-io', 'mruby-dir', 'mruby-tempfile'].each do |v|
+    add_dependency v
+  end
+
   spec.cc.include_paths << "#{build.root}/src"
 end
 


### PR DESCRIPTION
Missing depending mrbgems should be notified before building.
