### PR TITLE
Make compatible `self` in required file with normal ruby's.

### DIFF
--- a/mrblib/require.rb
+++ b/mrblib/require.rb
@@ -4,11 +4,11 @@ module Kernel
   begin
     eval "1", nil
     def _eval_load(*args)
-      Kernel.eval(*args)
+      self.eval(*args)
     end
   rescue ArgumentError
     def _eval_load(*args)
-      Kernel.eval(args[0])
+      self.eval(args[0])
     end
   end
 

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -1,0 +1,33 @@
+$dir = File.join(Dir.tmpdir, "mruby-require-test-#{Time.now.to_i}.#{Time.now.usec}")
+
+def test_setup
+  Dir.mkdir($dir) unless File.exist?($dir)
+
+  File.open(File.join($dir, "foo.rb"), "w") do |f|
+    f.puts "$require_context = self"
+  end
+end
+
+def test_cleanup
+  if $dir && File.exist?($dir)
+    Dir.entries($dir).each do |e|
+      next if ['.', '..'].include? e
+      File.unlink File.join($dir,e)
+    end
+    Dir.unlink $dir
+  end
+end
+
+
+#####
+test_setup
+#####
+
+assert("require context") do
+  require File.join($dir, 'foo.rb')
+  assert_equal self, $require_context
+end
+
+#####
+test_cleanup
+#####


### PR DESCRIPTION
Current implementation binds Kernel to self  in required file. This patch fixes it.