### PR TITLE
remove mruby-tempfile dependency

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,7 +5,6 @@ MRuby::Gem::Specification.new('mruby-require') do |spec|
   spec.add_dependency 'mruby-array-ext'
   spec.add_dependency 'mruby-dir'
   spec.add_dependency 'mruby-io'
-  spec.add_dependency 'mruby-tempfile'
   spec.add_dependency 'mruby-time'
   spec.add_dependency 'mruby-eval'
 


### PR DESCRIPTION
As far as I saw, `mruby-tempfile` is not used except for tests. 