### PR TITLE
Remove mruby io dependency

### DIFF
--- a/run_test.rb
+++ b/run_test.rb
@@ -21,7 +21,6 @@ MRuby::Build.new do |conf|
   conf.gembox 'default'
 
   conf.gem :core => 'mruby-eval'
-  conf.gem :git => 'https://github.com/iij/mruby-io.git'
   conf.gem :git => 'https://github.com/iij/mruby-dir.git'
   conf.gem :git => 'https://github.com/iij/mruby-tempfile.git'
 

--- a/run_test.rb
+++ b/run_test.rb
@@ -21,6 +21,7 @@ MRuby::Build.new do |conf|
   conf.gembox 'default'
 
   conf.gem :core => 'mruby-eval'
+  conf.gem :core => 'mruby-io'
   conf.gem :git => 'https://github.com/iij/mruby-dir.git'
   conf.gem :git => 'https://github.com/iij/mruby-tempfile.git'
 


### PR DESCRIPTION
Starting from 1.4.0, mruby bundles mruby-io