### PR TITLE
mruby 3.0 support

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,10 +3,10 @@ MRuby::Gem::Specification.new('mruby-require') do |spec|
   spec.authors = 'Internet Initiative Japan Inc.'
 
   spec.add_dependency 'mruby-array-ext'
-  spec.add_dependency 'mruby-dir'
   spec.add_dependency 'mruby-eval'
   spec.add_dependency 'mruby-io'
 
+  spec.add_test_dependency 'mruby-dir'
   spec.add_test_dependency 'mruby-tempfile'
   spec.add_test_dependency 'mruby-time'
 

--- a/mrblib/require.rb
+++ b/mrblib/require.rb
@@ -1,16 +1,6 @@
 class LoadError < ScriptError; end
 
 $__mruby_require_toplevel_self__ = self
-begin
-  eval "1", nil
-  def _require_eval_load(*args)
-    $__mruby_require_toplevel_self__.eval(*args)
-  end
-rescue ArgumentError
-  def _require_eval_load(*args)
-    $__mruby_require_toplevel_self__.eval(args[0])
-  end
-end
 
 module Kernel
   def load(path)
@@ -20,7 +10,7 @@ module Kernel
       _load_mrb_file path
     elsif File.exist?(path)
       # _load_rb_str File.open(path).read.to_s, path
-      _require_eval_load File.open(path).read.to_s, nil, path
+      $__mruby_require_toplevel_self__.eval(File.open(path).read.to_s, nil, path)
     else
       raise LoadError, "File not found -- #{path}"
     end


### PR DESCRIPTION
This PR makes changes so that the module works correctly with mruby 3.0.0.

For whatever reason, existing initialization code (the global `def` block) was raising TypeError, so I have simply removed the code in favor of calling the three-argument `eval` directly.

Even with these changes, the module still does not work with mruby 3.1.0, due to some weird reason where mruby complains that `:File` is missing.