### PR TITLE
Small improvements for mruby-3.1 support

### DIFF
--- a/mrblib/require.rb
+++ b/mrblib/require.rb
@@ -38,13 +38,13 @@ module Kernel
     filename = nil
     if ['/', '.'].include? path[0]
       path0 = filenames.find do |fname|
-        File.file?(fname)
+        ::File.file?(fname)
       end
     else
       dir = ($LOAD_PATH || []).find do |dir0|
         filename = filenames.find do |fname|
-          path0 = File.join dir0, fname
-          File.file?(path0)
+          path0 = ::File.join dir0, fname
+          ::File.file?(path0)
         end
       end
       path0 = dir && filename ? File.join(dir, filename) : nil


### PR DESCRIPTION
Address mruby-3.1.0-specific problem where constants cannot be referenced in certain blocks.

ref. https://github.com/mruby/mruby/issues/5725