### PR TITLE
Avoid including `mruby/src/{error,opcode}.h`

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -9,6 +9,4 @@ MRuby::Gem::Specification.new('mruby-require') do |spec|
   spec.add_test_dependency 'mruby-dir'
   spec.add_test_dependency 'mruby-tempfile'
   spec.add_test_dependency 'mruby-time'
-
-  spec.cc.include_paths << "#{build.root}/src"
 end

--- a/src/require.c
+++ b/src/require.c
@@ -11,8 +11,14 @@
 #include "mruby/string.h"
 #include "mruby/proc.h"
 
-#include "opcode.h"
-#include "error.h"
+#if defined(MRUBY_RELEASE_NO) && MRUBY_RELEASE_NO >= 10100
+#include "mruby/opcode.h"
+#include "mruby/error.h"
+#else
+#include "mruby/../../src/opcode.h"
+#include "mruby/../../src/error.h"
+#define MRUBY_RELEASE_NO 0
+#endif
 
 #include <stdlib.h>
 #include <sys/stat.h>


### PR DESCRIPTION
The `mruby/src/error.h` and `mruby/src/opcode.h` files are written as "to be removed soon".
For the record, mruby-1.0.0 can still be compiled.