### PR TITLE
Disable gem lockfile in `run_test.rb`

### DIFF
--- a/run_test.rb
+++ b/run_test.rb
@@ -16,6 +16,8 @@ if __FILE__ == $0
   exit system(%Q[cd #{dir}; MRUBY_CONFIG=#{File.expand_path __FILE__} ruby minirake #{build_args.join(' ')}])
 end
 
+MRuby::Lockfile.disable rescue nil
+
 MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'


### PR DESCRIPTION
Prevents changes made to other GEMs during development from ruining them.